### PR TITLE
4 strengthen tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
-    "eject": "react-app-rewired eject"
+    "eject": "react-app-rewired eject",
+    "lint": "eslint  --fix src/**/*.tsx"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -6,7 +6,7 @@ test('renders 1x1 board correctly', () => {
     const COLS: number = 1;
     const handlePlay = jest.fn();
 
-    render(<Board rows={ROWS} cols={COLS} onPlay={handlePlay} />);
+    render(<Board rows={ROWS} cols={COLS} values={[]} onPlay={handlePlay} />);
 
     const board: HTMLElement = screen.getByTestId('board');
     const cells: Array<HTMLElement> = within(board).getAllByRole('button');
@@ -18,7 +18,7 @@ test('renders 3x3 board correctly', () => {
     const COLS: number = 3;
     const handlePlay = jest.fn();
 
-    render(<Board rows={ROWS} cols={COLS} onPlay={handlePlay} />);
+    render(<Board rows={ROWS} cols={COLS} values={[]} onPlay={handlePlay} />);
 
     const board: HTMLElement = screen.getByTestId('board');
     const cells: Array<HTMLElement> = within(board).getAllByRole('button');
@@ -30,7 +30,7 @@ test('renders 5x3 board correctly', () => {
     const COLS: number = 3;
     const handlePlay = jest.fn();
 
-    render(<Board rows={ROWS} cols={COLS} onPlay={handlePlay} />);
+    render(<Board rows={ROWS} cols={COLS} values={[]} onPlay={handlePlay} />);
 
     const board: HTMLElement = screen.getByTestId('board');
     const cells: Array<HTMLElement> = within(board).getAllByRole('button');

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -1,7 +1,5 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import Board from './Board';
-import { act } from 'react-dom/test-utils';
-import userEvent from '@testing-library/user-event';
 
 test('renders 1x1 board correctly', () => {
     const ROWS: number = 1;
@@ -38,35 +36,3 @@ test('renders 5x3 board correctly', () => {
     const cells: Array<HTMLElement> = within(board).getAllByRole('button');
     expect(cells).toHaveLength(ROWS * COLS);
 });
-
-
-test('clicking cell once calls handler correctly', async () => {
-    const ROWS: number = 3;
-    const COLS: number = 3;
-    const handlePlay = jest.fn();
-
-    render(<Board rows={ROWS} cols={COLS} onPlay={handlePlay} />);
-
-    const board: HTMLElement = screen.getByTestId('board');
-    const cells: Array<HTMLElement> = within(board).getAllByRole('button');
-    expect(cells).toHaveLength(ROWS * COLS);
-
-    act(() => userEvent.click(cells[0]))
-    await waitFor(() => expect(handlePlay).toHaveBeenCalledWith(0, 1));
-});
-
-test('clicking cell twice calls handler correctly', async () => {
-    const ROWS: number = 3;
-    const COLS: number = 3;
-    const handlePlay = jest.fn();
-
-    render(<Board rows={ROWS} cols={COLS} onPlay={handlePlay} />);
-
-    const board: HTMLElement = screen.getByTestId('board');
-    const cells: Array<HTMLElement> = within(board).getAllByRole('button');
-    expect(cells).toHaveLength(ROWS * COLS);
-
-    act(() => userEvent.dblClick(cells[0]))
-    await waitFor(() => expect(handlePlay).toHaveBeenCalledWith(0, 2));
-});
-

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -14,7 +14,7 @@ function generateGrid(rows: number, cols: number): Array<Array<string>> {
     return new Array(rows).fill(0).map(() => new Array(cols).fill(0));
 }
 
-export default function Board({rows, cols, onPlay} : any) {
+export default function Board({rows, cols, values, onPlay} : any) {
     const grid: Array<Array<string>> = generateGrid(rows, cols);
 
     return (
@@ -23,7 +23,12 @@ export default function Board({rows, cols, onPlay} : any) {
                 row.map((col: string, colIdx: number) => {
                     const cellIdx: number = (rowIdx * cols) + colIdx;
                     return (
-                        <Cell key={`${rowIdx}-${colIdx}`} index={cellIdx} onClick={onPlay}></Cell>
+                        <Cell
+                            key={`${rowIdx}-${colIdx}`}
+                            index={cellIdx}
+                            value={values[cellIdx]}
+                            onClick={onPlay}>
+                        </Cell>
                     )
                 })
             )}

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -1,44 +1,52 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Cell from './Cell';
-import GameContext from '../core/gameContext';
+import { O_TOKEN, SECOND_CLICK_WAIT_TIME, S_TOKEN } from '../core/constants';
+import userEvent from '@testing-library/user-event';
 
-const contextValue: Array<string> = ['', '', '', '', 'S', '', 'O', '', ''];
+beforeEach(() => {
+  jest.useFakeTimers()
+})
 
-test('should be empty if not clicked', async () => {
-    const onClick = jest.fn();
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  jest.useRealTimers()
+})
 
-    render(
-        <GameContext.Provider value={contextValue}>
-            <Cell key="0-1" index={1} onClick={onClick}></Cell>
-        </GameContext.Provider>
-    );
+test('should render empty correctly', async () => {
+  const onClick = jest.fn();
 
-    const cells = screen.getAllByRole('button');
-    expect(cells[0]).toHaveTextContent(contextValue[1]);
+  render(<Cell key="0-1" index={1} value={''} onClick={onClick}></Cell>);
+
+  const cells = screen.getAllByRole('button');
+  expect(cells[0]).toBeEmptyDOMElement();
 });
 
-test('should show letter "O" on single click', async () => {
-    const onClick = jest.fn();
+test('should render value correctly', async () => {
+  const onClick = jest.fn();
 
-    render(
-        <GameContext.Provider value={contextValue}>
-            <Cell key="2-0" index={6} onClick={() => onClick(0, 1)}></Cell>
-        </GameContext.Provider>
-    );
+  render(<Cell key="2-0" index={6} value={O_TOKEN} onClick={() => onClick(0, 1)}></Cell>);
 
-    const cells = screen.getAllByRole('button');
-    expect(cells[0]).toHaveTextContent(contextValue[6]);
+  const cells = screen.getAllByRole('button');
+  expect(cells[0]).toHaveTextContent(O_TOKEN);
 });
 
-test('should show letter "S" on double click', async () => {
-    const onClick = jest.fn();
+test('should call hadler correctly on single click', async () => {
+  const onClick = jest.fn();
 
-    render(
-        <GameContext.Provider value={contextValue}>
-            <Cell key="1-1" index={4} onClick={() => onClick(0, 1)}></Cell>
-        </GameContext.Provider>
-    );
+  render(<Cell key="1-2" index={5} value={''} onClick={onClick}></Cell>);
 
-    const cells = screen.getAllByRole('button');
-    expect(cells[0]).toHaveTextContent(contextValue[4]);
+  const cells = screen.getAllByRole('button');
+  userEvent.click(cells[0]);
+  jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
+  expect(onClick).toHaveBeenCalledWith(5, 1);
+});
+
+test('should call hadler correctly on double click', async () => {
+  const onClick = jest.fn();
+
+  render(<Cell key="1-2" index={5} value={''} onClick={onClick}></Cell>);
+
+  const cells = screen.getAllByRole('button');
+  userEvent.dblClick(cells[0]);
+  expect(onClick).toHaveBeenCalledWith(5, 2);
 });

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -2,21 +2,43 @@ import { render, screen } from '@testing-library/react';
 import Cell from './Cell';
 import GameContext from '../core/gameContext';
 
-const contextValue: Array<string> = ['O', '', '', '', 'S', '', '', '', ''];
+const contextValue: Array<string> = ['', '', '', '', 'S', '', 'O', '', ''];
 
-test('shows correct content', () => {
+test('should be empty if not clicked', async () => {
     const onClick = jest.fn();
 
     render(
         <GameContext.Provider value={contextValue}>
-            <Cell key="0-0" index={0} onClick={() => onClick(0, 1)}></Cell>
-            <Cell key="0-2" index={2} onClick={() => onClick(2, 0)}></Cell>
-            <Cell key="1-1" index={4} onClick={() => onClick(4, 2)}></Cell>
+            <Cell key="0-1" index={1} onClick={onClick}></Cell>
         </GameContext.Provider>
     );
 
     const cells = screen.getAllByRole('button');
-    expect(cells[0]).toHaveTextContent(contextValue[0]);
-    expect(cells[1]).toHaveTextContent(contextValue[2]);
-    expect(cells[2]).toHaveTextContent(contextValue[4]);
+    expect(cells[0]).toHaveTextContent(contextValue[1]);
+});
+
+test('should show letter "O" on single click', async () => {
+    const onClick = jest.fn();
+
+    render(
+        <GameContext.Provider value={contextValue}>
+            <Cell key="2-0" index={6} onClick={() => onClick(0, 1)}></Cell>
+        </GameContext.Provider>
+    );
+
+    const cells = screen.getAllByRole('button');
+    expect(cells[0]).toHaveTextContent(contextValue[6]);
+});
+
+test('should show letter "S" on double click', async () => {
+    const onClick = jest.fn();
+
+    render(
+        <GameContext.Provider value={contextValue}>
+            <Cell key="1-1" index={4} onClick={() => onClick(0, 1)}></Cell>
+        </GameContext.Provider>
+    );
+
+    const cells = screen.getAllByRole('button');
+    expect(cells[0]).toHaveTextContent(contextValue[4]);
 });

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Cell from './Cell';
-import { O_TOKEN, SECOND_CLICK_WAIT_TIME, S_TOKEN } from '../core/constants';
+import { O_TOKEN, SECOND_CLICK_WAIT_TIME } from '../core/constants';
 import userEvent from '@testing-library/user-event';
 
 beforeEach(() => {

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -21,7 +21,10 @@ export default function Cell({ index, value, onClick }: any) {
     });
 
     function onClickHandler(event: React.MouseEvent<HTMLButtonElement>) {
-        if (value) return;
+        if (value) {
+            onClick(index, 1);
+            return;
+        };
 
         event.preventDefault();
         event.stopPropagation();

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -8,7 +8,7 @@ const Button = styled.button`
     font-size: 4rem;
 `;
 
-export default function Cell({className, index, onClick}: any) {
+export default function Cell({index, onClick}: any) {
     const value: string[] = useContext(GameContext);
     const timer = useRef<number | undefined>(undefined);
 
@@ -25,6 +25,6 @@ export default function Cell({className, index, onClick}: any) {
     const text: string = value.at(index) || '';
 
     return (
-        <Button type="button" className={className} onClick={onClickHandler}>{text}</Button>
+        <Button type="button" onClick={onClickHandler}>{text}</Button>
     );
 }

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
-import { useContext, useRef } from 'react';
-import GameContext from '../core/gameContext';
+import { useEffect, useRef } from 'react';
 import { SECOND_CLICK_WAIT_TIME } from '../core/constants';
 
 const Button = styled.button`
@@ -11,11 +10,31 @@ const Button = styled.button`
 export default function Cell({ index, value, onClick }: any) {
     const timer = useRef<number | undefined>(undefined);
 
+    // Runs on mount and on every re-render
+    useEffect(() => {
+        return () => {
+            if (timer.current) {
+                clearTimeout(timer.current);
+                timer.current = undefined;
+            }
+        };
+    });
+
     function onClickHandler(event: React.MouseEvent<HTMLButtonElement>) {
+        if (value) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
         clearTimeout(timer.current);
 
         if (event.detail === 1) {
-            timer.current = window.setTimeout(() => onClick(index, 1), SECOND_CLICK_WAIT_TIME);
+            timer.current = window.setTimeout(
+                () => {
+                    onClick(index, 1);
+                },
+                SECOND_CLICK_WAIT_TIME
+            );
         } else if (event.detail === 2) {
             onClick(index, 2);
         }

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -8,8 +8,7 @@ const Button = styled.button`
     font-size: 4rem;
 `;
 
-export default function Cell({index, onClick}: any) {
-    const value: string[] = useContext(GameContext);
+export default function Cell({ index, value, onClick }: any) {
     const timer = useRef<number | undefined>(undefined);
 
     function onClickHandler(event: React.MouseEvent<HTMLButtonElement>) {
@@ -22,9 +21,7 @@ export default function Cell({index, onClick}: any) {
         }
     }
 
-    const text: string = value.at(index) || '';
-
     return (
-        <Button type="button" onClick={onClickHandler}>{text}</Button>
+        <Button type="button" onClick={onClickHandler}>{value}</Button>
     );
 }

--- a/src/components/EndGameButton.test.tsx
+++ b/src/components/EndGameButton.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import EndGameButton from './EndGameButton';
+import userEvent from '@testing-library/user-event';
+
+test('is clickable', () => {
+    const onClick = jest.fn();
+
+    render(<EndGameButton onClick={onClick}></EndGameButton>);
+    const endGameButton: HTMLElement = screen.getByTestId('end-game-btn');
+    userEvent.click(endGameButton);
+    expect(onClick).toHaveBeenCalledTimes(1);
+});

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -12,25 +12,6 @@ afterEach(() => {
     jest.useRealTimers()
 })
 
-test('clicking cell once shows letter "O"', async () => {
-    render(<Game />)
-
-    const board: HTMLElement = screen.getByTestId('board');
-    const cells: Array<HTMLElement> = within(board).getAllByRole('button');
-    act(() => userEvent.click(cells[0]));
-
-    await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));   // For now, default timeout is ok (1000ms)
-});
-
-test('clicking cell twice shows letter "S"', async () => {
-    render(<Game />)
-
-    const board: HTMLElement = screen.getByTestId('board');
-    const cells: Array<HTMLElement> = within(board).getAllByRole('button');
-    act(() => userEvent.dblClick(cells[0]));
-    await waitFor(() => expect(cells[0]).toHaveTextContent(S_TOKEN));
-});
-
 test('if game ends with victory, status reflects the winner and board gets unclickable', async () => {
     render(<Game />)
 

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import Game from './Game';
 import userEvent from '@testing-library/user-event';
-import { O_TOKEN, S_TOKEN } from '../core/constants';
+import { O_TOKEN, SECOND_CLICK_WAIT_TIME, S_TOKEN } from '../core/constants';
 
 beforeEach(() => {
     jest.useFakeTimers()
@@ -22,6 +22,7 @@ test('if game ends with victory, status reflects the winner and board gets uncli
     const endGameBtn: HTMLElement = screen.getByTestId('end-game-btn');
 
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -32,6 +33,7 @@ test('if game ends with victory, status reflects the winner and board gets uncli
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[2]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[2]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
     act(() => userEvent.click(cells[0]));
@@ -46,6 +48,7 @@ test('if game ends with victory, status reflects the winner and board gets uncli
     await screen.findByText("It's Bob's turn")
 
     act(() => userEvent.click(cells[10]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[10]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
     act(() => userEvent.click(cells[0]));
@@ -81,6 +84,7 @@ test('if game ends with draw, status reflect it and board gets unclickable', asy
     const endGameBtn: HTMLElement = screen.getByTestId('end-game-btn');
 
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -91,6 +95,7 @@ test('if game ends with draw, status reflect it and board gets unclickable', asy
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[2]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[2]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
     act(() => userEvent.click(cells[0]));
@@ -105,6 +110,7 @@ test('if game ends with draw, status reflect it and board gets unclickable', asy
     await screen.findByText("It's Bob's turn")
 
     act(() => userEvent.click(cells[10]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[10]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
     act(() => userEvent.click(cells[0]));
@@ -150,6 +156,7 @@ test('renders history according to game state', async () => {
     const turnBtn: HTMLElement = screen.getByTestId('turn-btn');
 
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -160,6 +167,7 @@ test('renders history according to game state', async () => {
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[5]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[5]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -176,6 +184,7 @@ test('shows correct cells if a history record is selected', async () => {
     const turnBtn: HTMLElement = screen.getByTestId('turn-btn');
 
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -186,11 +195,13 @@ test('shows correct cells if a history record is selected', async () => {
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[5]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[5]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
 
     act(() => userEvent.click(cells[3]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[3]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Alice's turn`);
@@ -222,6 +233,7 @@ test('if past move is selected from history, keep present score', async () => {
 
     // Unnecessary long game
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -232,6 +244,7 @@ test('if past move is selected from history, keep present score', async () => {
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[2]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[2]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
     act(() => userEvent.click(cells[0]));
@@ -276,6 +289,7 @@ test('history should not be edited', async () => {
     const turnBtn: HTMLElement = screen.getByTestId('turn-btn');
 
     act(() => userEvent.click(cells[0]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[0]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(turnBtn));
     await screen.findByText(`It's Bob's turn`);
@@ -286,6 +300,7 @@ test('history should not be edited', async () => {
     await screen.findByText(`It's Alice's turn`);
 
     act(() => userEvent.click(cells[2]));
+    jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[2]).toHaveTextContent(O_TOKEN));
 
     const movesBtns: Array<HTMLElement> = screen.queryAllByText("Go to move", { exact: false });

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -36,11 +36,15 @@ test('if game ends with victory, status reflects the winner and board gets uncli
     jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
     await waitFor(() => expect(cells[2]).toHaveTextContent(O_TOKEN));
     act(() => userEvent.click(markBtn));
+    expect(turnBtn).not.toBeEnabled();
+    expect(markBtn).toBeEnabled();
     act(() => userEvent.click(cells[0]));
     act(() => userEvent.click(cells[1]));
     act(() => userEvent.click(cells[2]));
     await screen.findByText('Alice: 1');
     act(() => userEvent.click(markBtn));
+    expect(turnBtn).toBeEnabled();
+    expect(markBtn).toBeEnabled();
 
     act(() => userEvent.dblClick(cells[5]));
     await waitFor(() => expect(cells[5]).toHaveTextContent(S_TOKEN));

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -4,15 +4,14 @@ import History from './History'
 import { useState } from 'react';
 import { markIsValid, wordMarker } from '../core/algorithm';
 import { COLS, FIRST_PLAYER_NAME, O_TOKEN, ROWS, SECOND_PLAYER_NAME, S_TOKEN } from '../core/constants';
-import GameContext from '../core/gameContext';
 import TurnButton from './TurnButton';
 import MarkButton from './MarkButton';
 import EndGameButton from './EndGameButton';
 import { GameStatus, Scores } from '../core/models';
 import Status from './Status';
 
-  let generator = wordMarker();
-  generator.next();
+let generator = wordMarker();
+generator.next();
 
 export default function Game() {
     const [history, setHistory] = useState<Array<Array<string>>>([]);
@@ -129,20 +128,16 @@ export default function Game() {
 
     return (
         <>
-            <GameContext.Provider
-                value={cells}
-            >
-                <h1>OSO game</h1>
-                <div className="commands">
-                    <TurnButton onClick={switchTurn} isDisabled={canMark}></TurnButton>
-                    <MarkButton onClick={toggleMarker}></MarkButton>
-                    <EndGameButton onClick={endGame}></EndGameButton>
-                </div>
-                <Status message={message}/>
-                <Scoreboard scores={scores} />
-                <Board rows={ROWS} cols={COLS} onPlay={handlePlay} />
-                <History length={historyLength} currentMove={currentMove} onJump={handleJump} />
-            </GameContext.Provider>
+            <h1>OSO game</h1>
+            <div className="commands">
+                <TurnButton onClick={switchTurn} isDisabled={canMark}></TurnButton>
+                <MarkButton onClick={toggleMarker}></MarkButton>
+                <EndGameButton onClick={endGame}></EndGameButton>
+            </div>
+            <Status message={message}/>
+            <Scoreboard scores={scores} />
+            <Board rows={ROWS} cols={COLS} values={cells} onPlay={handlePlay} />
+            <History length={historyLength} currentMove={currentMove} onJump={handleJump} />
         </>
     );
 }

--- a/src/components/History.test.tsx
+++ b/src/components/History.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import History from './History';
 
-test('renders ok when length is 0', () => {
+test('is empty if there are no moves yet', () => {
     const handleJump = jest.fn();
 
     render(<History length={0} onJump={handleJump} currentMove={0}/>);
@@ -13,7 +13,7 @@ test('renders ok when length is 0', () => {
     expect(movesBtns).toHaveLength(0);
 });
 
-test('renders ok when length is 1', () => {
+test('shows one record if there has been only one move and last is disabled', () => {
     const handleJump = jest.fn();
 
     render(<History length={1} onJump={handleJump} currentMove={0}/>);
@@ -27,7 +27,7 @@ test('renders ok when length is 1', () => {
     expect(movesBtns[movesBtns.length - 1]).toBeDisabled();
 });
 
-test('renders ok when length greater than 1', () => {
+test('shows same amount of records as moves and last is disabled', () => {
     const handleJump = jest.fn();
 
     render(<History length={7} onJump={handleJump} currentMove={6}/>);
@@ -41,7 +41,7 @@ test('renders ok when length greater than 1', () => {
     expect(movesBtns[movesBtns.length - 1]).toBeDisabled();
 });
 
-test('last button should be enabled if some past move is selected', () => {
+test('last button should be enabled if some past move has been selected', () => {
     const handleJump = jest.fn();
 
     render(<History length={7} onJump={handleJump} currentMove={2}/>);

--- a/src/components/MarkButton.test.tsx
+++ b/src/components/MarkButton.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import MarkButton from './MarkButton';
+import userEvent from '@testing-library/user-event';
+
+test('is clickable', () => {
+    const onClick = jest.fn();
+
+    render(<MarkButton onClick={onClick}></MarkButton>);
+    const markButton: HTMLElement = screen.getByTestId('mark-btn');
+    userEvent.click(markButton);
+    expect(onClick).toHaveBeenCalledTimes(1);
+});

--- a/src/components/Scoreboard.test.tsx
+++ b/src/components/Scoreboard.test.tsx
@@ -3,7 +3,7 @@ import Scoreboard from './Scoreboard';
 import { Scores } from '../core/models';
 
 test('shows info correctly', () => {
-    const scores: Scores = [ { name: 'pepe', points: 10 }, { name: 'maría', points: 5 } ];
+    const scores: Scores = [ { name: 'Claire', points: 10 }, { name: 'Danny', points: 6 } ];
     render(<Scoreboard scores={scores} />);
 
     const score1: HTMLElement = screen.getByText("Claire: 10");

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -5,7 +5,7 @@ export default function Scoreboard({scores}: {scores: Scores}) {
         <>
             <ul>
                 {scores.map((s: Player) => (
-                    <li key={s.name}>{s.name}: {s.points}</li>
+                    <li key={s.name}><span>{s.name}: {s.points}</span></li>
                 ))}
             </ul>
         </>

--- a/src/components/Status.test.tsx
+++ b/src/components/Status.test.tsx
@@ -3,7 +3,7 @@ import Status from './Status';
 
 
 test('renders status correctly', () => {
-    const message: string = "Claire";
+    const message: string = "It's Ellie's turn";
 
     render(
         <Status message={message}></Status>

--- a/src/components/TurnButton.test.tsx
+++ b/src/components/TurnButton.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import TurnButton from './TurnButton';
+import userEvent from '@testing-library/user-event';
+
+
+test('button is clickable when it is not disabled', () => {
+    const onClick = jest.fn();
+
+    render(<TurnButton onClick={onClick} isDisabled={false}></TurnButton>);
+    const turnButton: HTMLElement = screen.getByTestId('turn-btn');
+    userEvent.click(turnButton);
+    expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test('button is not clickable when it is disabled', () => {
+    const onClick = jest.fn();
+
+    render(<TurnButton onClick={onClick} isDisabled={true}></TurnButton>);
+    const turnButton: HTMLElement = screen.getByTestId('turn-btn');
+    userEvent.click(turnButton);
+    expect(onClick).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
- When you click a cell, a timer starts to distinguish whether you want to put a O or S token. Do not wait for real time to pass in tests. What if the `setTimeout` is set to 15 seconds? Each test would last at least 15 seconds. If we wanted to run all the tests (and we do), it would take too long. So with `jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME)` we "imagine" that those 15 seconds already passed but... blazingly fast :)
- Remove some tests that weren't responsibility of the component
- Improve Scoreboard markup
- Add `package.json` script to lint and fix TSX files
- Test command buttons
- Improve overall tests description
- Get rid of context provider to simplify app structure. Component nesting is not that big.
- Use `useEffect()` hook to clear a cell timeout whenever the component rerenders, this is, it gets a new token value. This fixes a hidden bug that allowed clicking on multiple cells and putting the letter in the last one