### PR TITLE
13 oso word indices must belong to the same line

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -29,7 +29,10 @@ export default function Board({rows, cols, isDisabled, onPlay} : any) {
                     return (
                         <Cell
                             key={`${rowIdx}-${colIdx}`}
+                            id={cellIdx}
                             index={cellIdx}
+                            row={rowIdx}
+                            col={colIdx}
                             onClick={onPlay}
                             isDisabled={isDisabled}>
                         </Cell>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -18,7 +18,7 @@ function generateGrid(rows: number, cols: number): Array<Array<string>> {
     return new Array(rows).fill(0).map(() => new Array(cols).fill(0));
 }
 
-export default function Board({rows, cols, values, isDisabled, onPlay} : any) {
+export default function Board({rows, cols, isDisabled, onPlay} : any) {
     const grid: Array<Array<string>> = generateGrid(rows, cols);
 
     return (
@@ -30,7 +30,6 @@ export default function Board({rows, cols, values, isDisabled, onPlay} : any) {
                         <Cell
                             key={`${rowIdx}-${colIdx}`}
                             index={cellIdx}
-                            value={values[cellIdx]}
                             onClick={onPlay}
                             isDisabled={isDisabled}>
                         </Cell>

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import Cell from './Cell';
-import { O_TOKEN, SECOND_CLICK_WAIT_TIME } from '../core/constants';
-import userEvent from '@testing-library/user-event';
+import { O_TOKEN, S_TOKEN, SECOND_CLICK_WAIT_TIME } from '../core/constants';
+import { clickCells } from '../core/test-helpers';
 
 beforeEach(() => {
   jest.useFakeTimers()
@@ -15,38 +15,29 @@ afterEach(() => {
 test('should render empty correctly', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="0-1" index={1} value={''} onClick={onClick}></Cell>);
+  render(<Cell key="0-1" index={1} onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
   expect(cells[0]).toBeEmptyDOMElement();
 });
 
-test('should render value correctly', async () => {
+test('should call handler correctly on single click', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="2-0" index={6} value={O_TOKEN} onClick={() => onClick(0, 1)}></Cell>);
+  render(<Cell key="1-2" index={5} onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
-  expect(cells[0]).toHaveTextContent(O_TOKEN);
+  await clickCells([cells[0]]);
+  act(() => {jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);  });
+  expect(onClick).toHaveBeenCalledWith({ index: 5, token: O_TOKEN });
 });
 
-test('should call hadler correctly on single click', async () => {
+test('should call hadnler correctly on double click', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="1-2" index={5} value={''} onClick={onClick}></Cell>);
+  render(<Cell key="1-2" index={5} onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
-  userEvent.click(cells[0]);
-  jest.advanceTimersByTime(SECOND_CLICK_WAIT_TIME);
-  expect(onClick).toHaveBeenCalledWith(5, 1);
-});
-
-test('should call hadler correctly on double click', async () => {
-  const onClick = jest.fn();
-
-  render(<Cell key="1-2" index={5} value={''} onClick={onClick}></Cell>);
-
-  const cells = screen.getAllByRole('button');
-  userEvent.dblClick(cells[0]);
-  expect(onClick).toHaveBeenCalledWith(5, 2);
+  await clickCells([cells[0]], true);
+  expect(onClick).toHaveBeenCalledWith({ index: 5, token: S_TOKEN });
 });

--- a/src/components/Cell.test.tsx
+++ b/src/components/Cell.test.tsx
@@ -15,7 +15,7 @@ afterEach(() => {
 test('should render empty correctly', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="0-1" index={1} onClick={onClick}></Cell>);
+  render(<Cell key="0-1" index={1} row={0} col={1} onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
   expect(cells[0]).toBeEmptyDOMElement();
@@ -24,7 +24,7 @@ test('should render empty correctly', async () => {
 test('should call handler correctly on single click', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="1-2" index={5} onClick={onClick}></Cell>);
+  render(<Cell key="1-2" index={5} row={1} col={2} onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
   await clickCells([cells[0]]);
@@ -35,7 +35,7 @@ test('should call handler correctly on single click', async () => {
 test('should call hadnler correctly on double click', async () => {
   const onClick = jest.fn();
 
-  render(<Cell key="1-2" index={5} onClick={onClick}></Cell>);
+  render(<Cell key="1-2" index={5} row={1} col={2}onClick={onClick}></Cell>);
 
   const cells = screen.getAllByRole('button');
   await clickCells([cells[0]], true);

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
-import { useEffect, useRef } from 'react';
-import { SECOND_CLICK_WAIT_TIME } from '../core/constants';
+import { useEffect, useRef, useState } from 'react';
+import { O_TOKEN, S_TOKEN, SECOND_CLICK_WAIT_TIME } from '../core/constants';
 
 const Button = styled.button`
     background-color: white;
@@ -10,7 +10,8 @@ const Button = styled.button`
     aspect-ratio: 1 / 1;
 `;
 
-export default function Cell({ index, value, onClick, isDisabled }: any) {
+export default function Cell({ index, onClick, isDisabled }: any) {
+    const [token, setToken] = useState<string>('');
     const timer = useRef<number | undefined>(undefined);
 
     // Runs on mount and on every re-render
@@ -24,8 +25,8 @@ export default function Cell({ index, value, onClick, isDisabled }: any) {
     });
 
     function onClickHandler(event: React.MouseEvent<HTMLButtonElement>) {
-        if (value) {
-            onClick(index, 1);
+        if (token) {
+            onClick({ index, token });
             return;
         };
 
@@ -37,16 +38,18 @@ export default function Cell({ index, value, onClick, isDisabled }: any) {
         if (event.detail === 1) {
             timer.current = window.setTimeout(
                 () => {
-                    onClick(index, 1);
+                    setToken(O_TOKEN);
+                    onClick({ index, token: O_TOKEN });
                 },
                 SECOND_CLICK_WAIT_TIME
             );
         } else if (event.detail === 2) {
-            onClick(index, 2);
+            setToken(S_TOKEN);
+            onClick({ index, token: S_TOKEN });
         }
     }
 
     return (
-        <Button type="button" onClick={onClickHandler} disabled={isDisabled}>{value}</Button>
+        <Button type="button" onClick={onClickHandler} disabled={isDisabled}>{token}</Button>
     );
 }

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -10,7 +10,7 @@ const Button = styled.button`
     aspect-ratio: 1 / 1;
 `;
 
-export default function Cell({ index, onClick, isDisabled }: any) {
+export default function Cell({ id, index, row, col, onClick, isDisabled }: any) {
     const [token, setToken] = useState<string>('');
     const timer = useRef<number | undefined>(undefined);
 
@@ -26,7 +26,7 @@ export default function Cell({ index, onClick, isDisabled }: any) {
 
     function onClickHandler(event: React.MouseEvent<HTMLButtonElement>) {
         if (token) {
-            onClick({ index, token });
+            onClick({ id, index, row, col, token });
             return;
         };
 
@@ -39,13 +39,13 @@ export default function Cell({ index, onClick, isDisabled }: any) {
             timer.current = window.setTimeout(
                 () => {
                     setToken(O_TOKEN);
-                    onClick({ index, token: O_TOKEN });
+                    onClick({ id, index, row, col, token: O_TOKEN });
                 },
                 SECOND_CLICK_WAIT_TIME
             );
         } else if (event.detail === 2) {
             setToken(S_TOKEN);
-            onClick({ index, token: S_TOKEN });
+            onClick({ id, index, row, col, token: S_TOKEN });
         }
     }
 

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -208,10 +208,7 @@ export default function Game() {
                 // We expect another click. Do nothing.
             } else if (markedCells.value) {
                 const markIndices = markedCells.value.map(cell => cell.index);
-                console.log({markIndices})
-                const check1 = markExists(markIndices);
-                const check2 = wordIsValid(markedCells.value);
-                const isValid = !check1 && check2;
+                const isValid = !markExists(markIndices) && wordIsValid(markedCells.value);
                 if (isValid) {
                     updateMarks(markIndices);
                     updatePlayerScoreBy(activePlayer, 1);

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -1,7 +1,7 @@
 import Scoreboard from './Scoreboard'
 import Board from './Board'
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { compareNumbers, markIsValid, wordMarker } from '../core/algorithm';
+import { compareNumbers, wordIsValid, wordMarker } from '../core/algorithm';
 import { COLS, FIRST_PLAYER_NAME, ROWS, SECOND_PLAYER_NAME } from '../core/constants';
 import TurnButton from './TurnButton';
 import MarkButton from './MarkButton';
@@ -203,14 +203,17 @@ export default function Game() {
         }
 
         if(canMark) {
-            let markIndices = generator.next(cell.index);
-            if (!markIndices.done) {
+            let markedCells = generator.next(cell);
+            if (!markedCells.done) {
                 // We expect another click. Do nothing.
-            } else if (markIndices.value) {
-                const markTokens = markIndices.value.map(cellIdx => cells.filter(c => c.index === cellIdx)[0].token);
-                const isValid = !markExists(markIndices.value) && markIsValid(markTokens);
+            } else if (markedCells.value) {
+                const markIndices = markedCells.value.map(cell => cell.index);
+                console.log({markIndices})
+                const check1 = markExists(markIndices);
+                const check2 = wordIsValid(markedCells.value);
+                const isValid = !check1 && check2;
                 if (isValid) {
-                    updateMarks(markIndices.value);
+                    updateMarks(markIndices);
                     updatePlayerScoreBy(activePlayer, 1);
                 }
                 resetMarker();

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -23,6 +23,10 @@ export default function Game() {
     const [canMark, setCanMark] = useState<boolean>(false);
     const canvasRef = useRef<HTMLCanvasElement>({} as HTMLCanvasElement);
 
+    /**
+     * Draws the marks on the canvas
+     * @returns {void}
+     */
     const drawMarks = useCallback(() => {
         const canvas = canvasRef.current;
         const ctx = canvas.getContext('2d');
@@ -50,6 +54,10 @@ export default function Game() {
         drawMarks();
     }, [drawMarks]);
 
+    /**
+     * Sets the canvas width and height to match the parent container
+     * @returns {void}
+     */
     function setupCanvas(): void {
         const canvas = canvasRef.current;
         const rect = canvas.getBoundingClientRect();
@@ -57,6 +65,10 @@ export default function Game() {
         canvas.height = rect.height;
     }
 
+    /**
+     * Clears the canvas
+     * @returns {void}
+     */
     function clearCanvas(): void {
         const canvas = canvasRef.current;
         const ctx = canvas.getContext('2d');
@@ -65,6 +77,12 @@ export default function Game() {
         }
     }
 
+    /**
+     * Get the coordinates of the center of a cell respect to the canvas
+     * @param cellIdx - The index of the cell
+     * @param canvas - The canvas element
+     * @returns {Coordinate} - The coordinates of the center of the cell respect to the canvas
+     */
     function getCoordinates(cellIdx: number, canvas: HTMLCanvasElement): Coordinate {
         const rowIdx = Math.floor(cellIdx / COLS);
         const colIdx = cellIdx % COLS;
@@ -77,16 +95,31 @@ export default function Game() {
 
     const message: string = getMessage(status);
     
+    /**
+     * Checks if a cell is already filled
+     * @param index - The index of the cell to be checked
+     * @returns `true` if the cell is filled, otherwise `false`
+     */
     function isCellFilled(index: number): boolean {
         return !!cells[index];
     }
 
+    /**
+     * Add a new cell to the list of cells
+     * @param cell - The cell to be added
+     * @returns {void}
+     */
     function updateCells(cell: Cell): void {
         const newCells = [...cells];
         newCells.push(cell);
         setCells(newCells);
     }
 
+    /**
+     * Add a new mark to the list of marks
+     * @param newMark - An array of cell indices to be added
+     * @returns {void}
+     */
     function updateMarks(newMark: Mark): void {
         const newMarks: ArraySet<Mark> = new ArraySet();
         for (const mark of marks.values()) {
@@ -96,10 +129,22 @@ export default function Game() {
         setMarks(newMarks);
     }
 
+    /**
+     * Checks if any player already marked the given cells as a word
+     * 
+    * @param {Mark} mark - An array of cell indices to be checked.
+    * @returns {boolean} - Returns `true` if the mark already exists, otherwise `false`.
+    */
     function markExists(mark: Mark): boolean {
         return marks.has(mark.sort(compareNumbers));
     }
 
+    /**
+     * Updates the score of the player with the given name
+     * @param playerName - The name of the player
+     * @param increment - The amount to increment the score by
+     * @returns {void}
+     */
     function updatePlayerScoreBy(playerName: string, increment: number): void {
         let updatedScores = [...scores]
         const foundIdx = updatedScores.findIndex(s => s.name === playerName);
@@ -109,14 +154,27 @@ export default function Game() {
         setScores(updatedScores)
     }
 
+    /**
+     * Checks if the game is a draw
+     * @returns {boolean} - Returns `true` if the game is a draw, otherwise `false`.
+     */
     function isADraw(): boolean {
         return scores.every(s => s.points === scores[0].points);
     }
 
+    /**
+     * Get the name of the player with the highest score
+     * @returns {string} - The name of the player with the highest score
+     */
     function getWinner(): string {
        return scores.reduce((a: Player, b: Player) => a.points >= b.points ? a : b ).name;
     }
 
+    /**
+     * Get the message to be displayed based on the game status
+     * @param type - The game status
+     * @returns {string} - The message to be displayed
+     */
     function getMessage(type: GameStatus): string {
         let message: string = "";
         switch (type) {
@@ -135,6 +193,10 @@ export default function Game() {
         return message;
     }
 
+    /**
+     * Handles the play event. The brain of the game. It controls when the player can play, mark a word, or end the game
+     * @param cell - The cell that was clicked
+     */
     function handlePlay(cell: Cell): void {
         if(status === GameStatus.ENDED) {
             return;
@@ -162,10 +224,17 @@ export default function Game() {
         }
     }
 
+    /**
+     * Switches the turn to the next player
+     */
     function switchTurn(): void {
         setActivePlayer(activePlayer === FIRST_PLAYER_NAME ? SECOND_PLAYER_NAME : FIRST_PLAYER_NAME);
     }
 
+    /**
+     * Toggles the marker on and off. When on, allows a player to mark a word on the board. When off, the player can play normally
+     * @returns {void}
+     */
     function toggleMarker(): void {
         if(canMark) {
             resetMarker();
@@ -173,10 +242,18 @@ export default function Game() {
         setCanMark(!canMark);
     }
 
+    /**
+     * Ends the game
+     * @returns {void}
+     */
     function endGame(): void {
         setStatus(GameStatus.ENDED);
     }
 
+    /**
+     * Resets the marker. Neccesary for the player to mark a new word
+     * @returns {void}
+     */
     function resetMarker(): void {
         generator = wordMarker();
         generator.next();

--- a/src/core/algorithm.test.ts
+++ b/src/core/algorithm.test.ts
@@ -1,35 +1,35 @@
-import { wordIsValid, markIsValid, wordMarker } from "./algorithm";
+import { wordIsValid, wordMarker } from "./algorithm";
+import { O_TOKEN, S_TOKEN } from "./constants";
 import { Word } from "./models";
 
-test('marked word is valid', () => {
-    const mark: Array<string> = ['O', 'S', 'O'];
-    expect(markIsValid(mark)).toBe(true);
-});
-
-test('marked word is invalid', () => {
-    const invalidMarks: Array<Array<string>> = [
-        ['O', 'O', 'O'],
-        ['O', 'O', 'S'],
-        ['O', 'S', 'S'],
-        ['S', 'S', 'S'],
-        ['S', 'S', 'O'],
-        ['S', 'O', 'O'],
-        ['S', 'O', 'S']
+test('word is valid', () => {
+    const validWords: Array<Word> = [
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 2, row: 0, col: 2, token: 'O' }],
+        [{ index: 2, row: 0, col: 2, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 8, row: 2, col: 0, token: 'O' }],
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 10, row: 2, col: 2, token: 'O' }],
+        [{ index: 2, row: 0, col: 2, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],
+        [{ index: 8, row: 2, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],
+        [{ index: 10, row: 2, col: 2, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 6, row: 1, col: 2, token: 'S' }, { index: 9, row: 2, col: 1, token: 'O' }],
+        [{ index: 7, row: 1, col: 3, token: 'O' }, { index: 10, row: 2, col: 2, token: 'S' }, { index: 13, row: 3, col: 1, token: 'O' }],
+        [{ index: 13, row: 3, col: 1, token: 'O' }, { index: 10, row: 2, col: 2, token: 'S' }, { index: 7, row: 1, col: 3, token: 'O' }],
     ];
-    for (const mark of invalidMarks) {
-        expect(markIsValid(mark)).toBe(false);   
+
+    for (const word of validWords) {
+        expect(wordIsValid(word)).toBe(true);   
     }
 });
 
 test('word is invalid because of tokens', () => {
     const invalidWords: Array<Word> = [
-        [{ index: 0, token: 'O' }, { index: 1, token: 'O' }, { index: 2, token: 'O' }],
-        [{ index: 0, token: 'O' }, { index: 1, token: 'O' }, { index: 2, token: 'S' }],
-        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 2, token: 'S' }],
-        [{ index: 0, token: 'S' }, { index: 1, token: 'S' }, { index: 2, token: 'S' }],
-        [{ index: 0, token: 'S' }, { index: 1, token: 'S' }, { index: 2, token: 'O' }],
-        [{ index: 0, token: 'S' }, { index: 1, token: 'O' }, { index: 2, token: 'O' }],
-        [{ index: 0, token: 'S' }, { index: 1, token: 'O' }, { index: 2, token: 'S' }]
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'O' }, { index: 2, row: 0, col: 2, token: 'O' }],
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'O' }, { index: 2, row: 0, col: 2, token: 'S' }],
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 2, row: 0, col: 2, token: 'S' }],
+        [{ index: 0, row: 0, col: 0, token: 'S' }, { index: 1, row: 0, col: 1, token: 'O' }, { index: 2, row: 0, col: 2, token: 'O' }],
+        [{ index: 0, row: 0, col: 0, token: 'S' }, { index: 1, row: 0, col: 1, token: 'O' }, { index: 2, row: 0, col: 2, token: 'S' }],
+        [{ index: 0, row: 0, col: 0, token: 'S' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 2, row: 0, col: 2, token: 'O' }],
+        [{ index: 0, row: 0, col: 0, token: 'S' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 2, row: 0, col: 2, token: 'S' }],
     ];
     for (const word of invalidWords) {
         expect(wordIsValid(word)).toBe(false);   
@@ -39,21 +39,46 @@ test('word is invalid because of tokens', () => {
 test('word is invalid because of indices', () => {
     // TODO: Assume a 4x4 grid. This test will fail if the ROWS constant is changed. Find a way to make this test independent of ROWS or set ROWS to 4 in this test.
     const invalidWords: Array<Word> = [
-        // rows
-        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 3, token: 'O' }],    // skipped indices in the same row
-        [{ index: 3, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // skipped indices in the same row in reverse order
-        [{ index: 1, token: 'O' }, { index: 3, token: 'S' }, { index: 2, token: 'O' }],    // indices in incorrect order in the same row
-        [{ index: 2, token: 'O' }, { index: 3, token: 'S' }, { index: 1, token: 'O' }],    // indices in incorrect order in the same row in reverse order
-        [{ index: 2, token: 'O' }, { index: 3, token: 'S' }, { index: 0, token: 'O' }],    // indices that wrap the row
-        [{ index: 0, token: 'O' }, { index: 3, token: 'S' }, { index: 2, token: 'O' }],    // indices that wrap the row in reverse order
-        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 4, token: 'O' }],    // indices that jump to the next row
-        [{ index: 4, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // indices that jump to the next row in reverse order
-        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 8, token: 'O' }],    // indices that jump to another row
-        [{ index: 8, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // indices that jump to another row in reverse order
-        // cols
-        [{ index: 0, token: 'O' }, { index: 4, token: 'S' }, { index: 12, token: 'O' }],   // skipped indices in the same column
-        [{ index: 12, token: 'O' }, { index: 4, token: 'S' }, { index: 0, token: 'O' }],   // skipped indices in the same column in reverse order
-        [{ index: 4, token: 'O' }, { index: 12, token: 'S' }, { index: 8, token: 'O' }],   // indices in incorrect order in the same column
+        // rows (ordinary and reverse order)
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 3, row: 0, col: 3, token: 'O' }],    // skipped indices in the same row
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 1, row: 1, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // skipped indices in the same row in reverse order
+        [{ index: 1, row: 0, col: 1, token: 'O' }, { index: 3, row: 0, col: 3, token: 'S' }, { index: 2, row: 0, col: 2, token: 'O' }],    // indices in incorrect order in the same row
+        [{ index: 2, row: 0, col: 2, token: 'O' }, { index: 3, row: 0, col: 3, token: 'S' }, { index: 1, row: 0, col: 1, token: 'O' }],    // indices in incorrect order in the same row in reverse order
+        [{ index: 2, row: 0, col: 2, token: 'O' }, { index: 3, row: 0, col: 3, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that wrap the row
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 3, row: 0, col: 3, token: 'S' }, { index: 2, row: 0, col: 2, token: 'O' }],    // indices that wrap the row in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 4, row: 1, col: 0, token: 'O' }],    // indices that jump to the next row
+        [{ index: 4, row: 1, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that jump to the next row in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 8, row: 2, col: 0, token: 'O' }],    // indices that jump to another row
+        [{ index: 8, row: 2, col: 0, token: 'O' }, { index: 1, row: 0, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that jump to another row in reverse order
+        // cols (ordinary and reverse order)
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 12, row: 3, col: 0, token: 'O' }],   // skipped indices in the same column
+        [{ index: 12, row: 3, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],   // skipped indices in the same column in reverse order
+        [{ index: 4, row: 1, col: 0, token: 'O' }, { index: 12, row: 3, col: 0, token: 'S' }, { index: 8, row: 2, col: 0, token: 'O' }],   // indices in incorrect order in the same column
+        [{ index: 8, row: 2, col: 0, token: 'O' }, { index: 12, row: 3, col: 0, token: 'S' }, { index: 4, row: 1, col: 0, token: 'O' }],    // indices in incorrect order in the same column in reverse order
+        [{ index: 8, row: 2, col: 0, token: 'O' }, { index: 12, row: 3, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that wrap the column
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 12, row: 0, col: 3, token: 'S' }, { index: 8, row: 0, col: 2, token: 'O' }],    // indices that wrap the column in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 1, row: 0, col: 1, token: 'O' }],    // indices that jump to the next column
+        [{ index: 1, row: 0, col: 1, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that jump to the next column in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 2, row: 0, col: 2, token: 'O' }],    // indices that jump to the next column
+        [{ index:21, row: 0, col: 2, token: 'O' }, { index: 4, row: 1, col: 0, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that jump to another column in reverse order
+        // diagonal top-left to bottom-right (ordinary and reverse order)
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 15, row: 3, col: 3, token: 'O' }],    // skipped indices in the same diagonal
+        [{ index: 15, row: 3, col: 3, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // skipped indices in the same diagonal in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 10, row: 2, col: 2, token: 'S' }, { index: 5, row: 1, col: 1, token: 'O' }],    // indices in incorrect order in the same diagonal
+        [{ index: 5, row: 1, col: 1, token: 'O' }, { index: 10, row: 2, col: 2, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices in incorrect order in the same diagonal in reverse order
+        [{ index: 10, row: 2, col: 2, token: 'O' }, { index: 15, row: 3, col: 3, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that wrap the diagonal
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 15, row: 3, col: 3, token: 'S' }, { index: 10, row: 2, col: 2, token: 'O' }],    // indices that wrap the diagonal in reverse order
+        [{ index: 0, row: 0, col: 0, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 6, row: 1, col: 2, token: 'O' }],    // indices that jump to another diagonal
+        [{ index: 6, row: 1, col: 2, token: 'O' }, { index: 5, row: 1, col: 1, token: 'S' }, { index: 0, row: 0, col: 0, token: 'O' }],    // indices that jump to another diagonal in reverse order
+        // diagonal bottom-left to top-right (ordinary and reverse order)
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 6, row: 1, col: 2, token: 'S' }, { index: 12, row: 3, col: 0, token: 'O' }],    // skipped indices in the same diagonal
+        [{ index: 12, row: 3, col: 0, token: 'O' }, { index: 6, row: 1, col: 2, token: 'S' }, { index: 3, row: 0, col: 3, token: 'O' }],    // skipped indices in the same diagonal in reverse order
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 9, row: 2, col: 1, token: 'S' }, { index: 6, row: 1, col: 2, token: 'O' }],    // indices in incorrect order in the same diagonal
+        [{ index: 6, row: 1, col: 2, token: 'O' }, { index: 9, row: 2, col: 1, token: 'S' }, { index: 3, row: 0, col: 3, token: 'O' }],    // indices in incorrect order in the same diagonal in reverse order
+        [{ index: 9, row: 1, col: 3, token: 'O' }, { index: 12, row: 2, col: 2, token: 'S' }, { index: 3, row: 0, col: 3, token: 'O' }],    // indices that wrap the diagonal
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 12, row: 2, col: 2, token: 'S' }, { index: 9, row: 1, col: 3, token: 'O' }],    // indices that wrap the diagonal in reverse order
+        [{ index: 3, row: 0, col: 3, token: 'O' }, { index: 6, row: 1, col: 2, token: 'S' }, { index: 5, row: 1, col: 1, token: 'O' }],    // indices that jump to another diagonal
+        [{ index: 5, row: 1, col: 1, token: 'O' }, { index: 6, row: 1, col: 2, token: 'S' }, { index: 3, row: 0, col: 3, token: 'O' }],    // indices that jump to another diagonal in reverse order
     ];
     for (const word of invalidWords) {
         expect(wordIsValid(word)).toBe(false);   
@@ -63,8 +88,8 @@ test('word is invalid because of indices', () => {
 test('marker generator returns 3 indexes', () => {
     const generator = wordMarker();
     generator.next();
-    generator.next(4);
-    generator.next(0);
-    const { value } = generator.next(6);
-    expect((value as Array<number>).length).toBe(3);
+    generator.next({ index: 4, row: 1, col: 0, token: O_TOKEN });
+    generator.next({ index: 0, row: 0, col: 0, token: S_TOKEN });
+    const { value } = generator.next({ index: 6, row: 1, col: 2, token: O_TOKEN });
+    expect((value as Word).length).toBe(3);
 });

--- a/src/core/algorithm.test.ts
+++ b/src/core/algorithm.test.ts
@@ -1,4 +1,5 @@
-import { markIsValid, wordMarker } from "./algorithm";
+import { wordIsValid, markIsValid, wordMarker } from "./algorithm";
+import { Word } from "./models";
 
 test('marked word is valid', () => {
     const mark: Array<string> = ['O', 'S', 'O'];
@@ -17,6 +18,45 @@ test('marked word is invalid', () => {
     ];
     for (const mark of invalidMarks) {
         expect(markIsValid(mark)).toBe(false);   
+    }
+});
+
+test('word is invalid because of tokens', () => {
+    const invalidWords: Array<Word> = [
+        [{ index: 0, token: 'O' }, { index: 1, token: 'O' }, { index: 2, token: 'O' }],
+        [{ index: 0, token: 'O' }, { index: 1, token: 'O' }, { index: 2, token: 'S' }],
+        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 2, token: 'S' }],
+        [{ index: 0, token: 'S' }, { index: 1, token: 'S' }, { index: 2, token: 'S' }],
+        [{ index: 0, token: 'S' }, { index: 1, token: 'S' }, { index: 2, token: 'O' }],
+        [{ index: 0, token: 'S' }, { index: 1, token: 'O' }, { index: 2, token: 'O' }],
+        [{ index: 0, token: 'S' }, { index: 1, token: 'O' }, { index: 2, token: 'S' }]
+    ];
+    for (const word of invalidWords) {
+        expect(wordIsValid(word)).toBe(false);   
+    }
+});
+
+test('word is invalid because of indices', () => {
+    // TODO: Assume a 4x4 grid. This test will fail if the ROWS constant is changed. Find a way to make this test independent of ROWS or set ROWS to 4 in this test.
+    const invalidWords: Array<Word> = [
+        // rows
+        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 3, token: 'O' }],    // skipped indices in the same row
+        [{ index: 3, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // skipped indices in the same row in reverse order
+        [{ index: 1, token: 'O' }, { index: 3, token: 'S' }, { index: 2, token: 'O' }],    // indices in incorrect order in the same row
+        [{ index: 2, token: 'O' }, { index: 3, token: 'S' }, { index: 1, token: 'O' }],    // indices in incorrect order in the same row in reverse order
+        [{ index: 2, token: 'O' }, { index: 3, token: 'S' }, { index: 0, token: 'O' }],    // indices that wrap the row
+        [{ index: 0, token: 'O' }, { index: 3, token: 'S' }, { index: 2, token: 'O' }],    // indices that wrap the row in reverse order
+        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 4, token: 'O' }],    // indices that jump to the next row
+        [{ index: 4, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // indices that jump to the next row in reverse order
+        [{ index: 0, token: 'O' }, { index: 1, token: 'S' }, { index: 8, token: 'O' }],    // indices that jump to another row
+        [{ index: 8, token: 'O' }, { index: 1, token: 'S' }, { index: 0, token: 'O' }],    // indices that jump to another row in reverse order
+        // cols
+        [{ index: 0, token: 'O' }, { index: 4, token: 'S' }, { index: 12, token: 'O' }],   // skipped indices in the same column
+        [{ index: 12, token: 'O' }, { index: 4, token: 'S' }, { index: 0, token: 'O' }],   // skipped indices in the same column in reverse order
+        [{ index: 4, token: 'O' }, { index: 12, token: 'S' }, { index: 8, token: 'O' }],   // indices in incorrect order in the same column
+    ];
+    for (const word of invalidWords) {
+        expect(wordIsValid(word)).toBe(false);   
     }
 });
 

--- a/src/core/algorithm.ts
+++ b/src/core/algorithm.ts
@@ -1,6 +1,15 @@
-import { O_TOKEN, ROWS, S_TOKEN, WORD_SIZE } from "./constants";
+import { O_TOKEN, S_TOKEN, WORD_SIZE } from "./constants";
 import { Cell, Word } from "./models";
 
+/**
+ * Checks if the given word is valid based on the following criteria:
+ * - The word must have the correct number of cells (WORD_SIZE).
+ * - The tokens must be in the correct order ('O', 'S', 'O').
+ * - The cells must be aligned in the same row, column, or diagonal.
+ * 
+ * @param {Word} word - An array of Cell objects representing the word.
+ * @returns {boolean} - Returns `true` if the word is valid, otherwise `false`.
+ */
 export function wordIsValid(word: Word): boolean {
 // Check if the selection has the correct number of cells
   if (word.length !== WORD_SIZE) {
@@ -72,6 +81,14 @@ for (let i = 1; i < word.length; i++) {
   return true;
 }
 
+/**
+ * A generator function that yields the current state of the word being formed.
+ * 
+ * Keeps track of the cells that have been clicked in order to form a word.
+ * It yields the current state of the word each time a new cell is added.
+ * 
+ * @yields {Word} - The current state of the word being formed.
+ */
 export function* wordMarker(): Generator<number, Word, Cell> {
   let clickedCells: Word = [];
   for (let i = 0; i < WORD_SIZE; i++) {
@@ -83,6 +100,15 @@ export function* wordMarker(): Generator<number, Word, Cell> {
   return clickedCells;
 }
 
+/**
+ * Compares two numbers and returns a value indicating their relative order.
+ * 
+ * This function is used as a comparator for sorting numbers in ascending order.
+ * 
+ * @param {number} a - The first number to compare.
+ * @param {number} b - The second number to compare.
+ * @returns {number} - Returns a negative value if `a` is less than `b`, zero if they are equal, and a positive value if `a` is greater than `b`.
+ */
 export function compareNumbers(a: number, b: number): number {
   return a - b;
 }

--- a/src/core/algorithm.ts
+++ b/src/core/algorithm.ts
@@ -1,14 +1,45 @@
+import { O_TOKEN, ROWS, S_TOKEN, WORD_SIZE } from "./constants";
+import { Word } from "./models";
+
 export function markIsValid(markedCells: Array<string>): boolean {
-    if (markedCells.length !== 3) {
+    if (markedCells.length !== WORD_SIZE) {
       return false; 
     }
-    return (markedCells[0] === 'O' && markedCells[1] === 'S' && markedCells[2] === 'O');
+    return (markedCells[0] === O_TOKEN && markedCells[1] === S_TOKEN && markedCells[2] === O_TOKEN);
+}
+
+export function wordIsValid(cellSelection: Word): boolean {
+// Check if the selection has the correct number of cells
+  if (cellSelection.length !== WORD_SIZE) {
+    return false; 
+  }
+
+  // Check if the tokens are in the correct order
+  if (cellSelection[0].token !== O_TOKEN || cellSelection[1].token !== S_TOKEN || cellSelection[2].token !== O_TOKEN) {
+    return false;
+  }
+
+  // Check if the indices are in the same row and do not wrap to the next line
+  const row = Math.floor(cellSelection[0].index / ROWS);
+  for (let i = 1; i < cellSelection.length; i++) {
+    if (Math.floor(cellSelection[i].index / ROWS) !== row) {
+      return false;
+    }
+  }
+
+  // Check if the indices are consecutive
+  for (let i = 1; i < cellSelection.length; i++) {
+      if (cellSelection[i].index !== cellSelection[i - 1].index + 1) {
+          return false;
+      }
+  }
+
+  return true;
 }
 
 export function* wordMarker(): Generator<number, Array<number>, number> {
-  const wordSize = 3;
   let clickedCells: Array<number> = [];
-  for (let i = 0; i < wordSize; i++) {
+  for (let i = 0; i < WORD_SIZE; i++) {
         let cellIdx: number = yield i;
         if(!cellIdx && cellIdx !== 0) break;
         clickedCells.push(cellIdx);

--- a/src/core/algorithm.ts
+++ b/src/core/algorithm.ts
@@ -1,48 +1,83 @@
 import { O_TOKEN, ROWS, S_TOKEN, WORD_SIZE } from "./constants";
-import { Word } from "./models";
+import { Cell, Word } from "./models";
 
-export function markIsValid(markedCells: Array<string>): boolean {
-    if (markedCells.length !== WORD_SIZE) {
-      return false; 
-    }
-    return (markedCells[0] === O_TOKEN && markedCells[1] === S_TOKEN && markedCells[2] === O_TOKEN);
-}
-
-export function wordIsValid(cellSelection: Word): boolean {
+export function wordIsValid(word: Word): boolean {
 // Check if the selection has the correct number of cells
-  if (cellSelection.length !== WORD_SIZE) {
+  if (word.length !== WORD_SIZE) {
     return false; 
   }
 
   // Check if the tokens are in the correct order
-  if (cellSelection[0].token !== O_TOKEN || cellSelection[1].token !== S_TOKEN || cellSelection[2].token !== O_TOKEN) {
+  if (word[0].token !== O_TOKEN || word[1].token !== S_TOKEN || word[2].token !== O_TOKEN) {
     return false;
   }
 
-  // Check if the indices are in the same row and do not wrap to the next line
-  const row = Math.floor(cellSelection[0].index / ROWS);
-  for (let i = 1; i < cellSelection.length; i++) {
-    if (Math.floor(cellSelection[i].index / ROWS) !== row) {
+  // Check if the cells are in the same row, column, or diagonal  
+  const row = word[0].row;
+  const col = word[0].col;
+
+  let sameRow = true;
+  let sameCol = true;
+  let sameDiagonal1 = true; // Top-left to bottom-right
+  let sameDiagonal2 = true; // Top-right to bottom-left
+
+  for (let i = 1; i < word.length; i++) {
+    if (word[i].row !== row) {
+      sameRow = false;
+    }
+    if (word[i].col !== col) {
+      sameCol = false;
+    }
+    if (word[i].row - word[i].col !== (row - col)) {
+      sameDiagonal1 = false;
+    }
+    if ((word[i].row + word[i].col) !== (row + col)) {
+      sameDiagonal2 = false;
+    }
+    if (!sameRow && !sameCol && !sameDiagonal1 && !sameDiagonal2) {
       return false;
     }
   }
 
-  // Check if the indices are consecutive
-  for (let i = 1; i < cellSelection.length; i++) {
-      if (cellSelection[i].index !== cellSelection[i - 1].index + 1) {
-          return false;
-      }
+// Check if the indices are consecutive in the same row, column, or diagonal
+for (let i = 1; i < word.length; i++) {
+  const currCell = word[i];
+  const prevCell = word[i - 1];
+
+  // Check if consecutive in the same row (both ascending and descending)
+  if (currCell.col === prevCell.col + 1 || currCell.col === prevCell.col - 1) {
+      continue;
   }
+
+  // Check if consecutive in the same column (both ascending and descending)
+  if (currCell.row === prevCell.row + 1 || currCell.row === prevCell.row - 1) {
+      continue;
+  }
+
+  // Check if consecutive in the same diagonal (top-left to bottom-right, both ascending and descending)
+  if (currCell.col === prevCell.col + 1 && currCell.row === prevCell.row + 1) {
+      continue;
+  }
+
+  // Check if consecutive in the same diagonal (top-right to bottom-left, both ascending and descending)
+  if (currCell.col === prevCell.col - 1 && currCell.row === prevCell.row - 1) {
+      continue;
+  }
+
+  // If none of the conditions are met, return false
+  return false;
+}
+
 
   return true;
 }
 
-export function* wordMarker(): Generator<number, Array<number>, number> {
-  let clickedCells: Array<number> = [];
+export function* wordMarker(): Generator<number, Word, Cell> {
+  let clickedCells: Word = [];
   for (let i = 0; i < WORD_SIZE; i++) {
-        let cellIdx: number = yield i;
-        if(!cellIdx && cellIdx !== 0) break;
-        clickedCells.push(cellIdx);
+        let cell: Cell = yield i;
+        if(!cell.index && cell.index !== 0) break;
+        clickedCells.push(cell);
   }
 
   return clickedCells;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -6,5 +6,6 @@ export const SECOND_PLAYER_NAME : string = 'Bob';
 
 export const O_TOKEN : string = 'O';
 export const S_TOKEN: string = 'S';
+export const WORD_SIZE: number = 3;
 
 export const SECOND_CLICK_WAIT_TIME = 200;

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -19,6 +19,9 @@ export interface Coordinate {
 export type Word = Array<Cell>;
 
 export interface Cell {
+    id?: number;
     index: number;
+    row: number;
+    col: number;
     token: string;
 }

--- a/src/core/models.ts
+++ b/src/core/models.ts
@@ -10,9 +10,15 @@ export enum GameStatus {
     ENDED
 };
 
-export type Cell = string;
 export type Mark = Array<number>;
 export interface Coordinate {
     x: number;
     y: number;
 };
+
+export type Word = Array<Cell>;
+
+export interface Cell {
+    index: number;
+    token: string;
+}


### PR DESCRIPTION
- Improve models. Cell now contain its row and col indices. Define Word as an array of Cells.
- Improve validation algorithm. Control that the three indices belong to the same line, doesn't mind if it is a row, a column or a diagonal (fixes #13 ).
- The Cell component now saves the token in state.
- Add JSDoc comments.